### PR TITLE
Use RecursivePartial to correctly type nested interfaces

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,12 @@
-export function stub<T extends {}>(base: Partial<T> = {}): T {
+// RecursivePartial definition based on https://stackoverflow.com/a/51365037
+type RecursivePartial<T> = {
+  [P in keyof T]?:
+    T[P] extends (infer U)[] ? RecursivePartial<U>[] :
+    T[P] extends object ? RecursivePartial<T[P]> :
+    T[P];
+};
+
+export function stub<T extends {}>(base: RecursivePartial<T> = {}): T {
   const store = new Map();
   return new Proxy(base, {
     get(target, prop) {


### PR DESCRIPTION
Based on https://stackoverflow.com/a/51365037

This would make all properties on all depths optional, instead of just
the first level of the stubbed interface/class